### PR TITLE
Add environment variable support and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.idea/
+.vscode/
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Discord Trade Bot
+
+Simple Discord bot to handle auctions via forum threads.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set environment variables:
+   - `DISCORD_TOKEN` - your bot token.
+   - `FORUM_CHANNEL_ID` - ID of the forum channel for auctions.
+
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```

--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands, tasks
 from discord.ui import Modal, TextInput, View, Button, Select
@@ -7,7 +8,7 @@ import asyncio
 intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
 
-forum_channel_id = 123456789012345678  # Zmień na ID Twojego kanału-forum
+forum_channel_id = int(os.environ["FORUM_CHANNEL_ID"])
 active_auctions = {}  # message_id: {...}
 
 class AuctionModal(Modal, title="Nowa Licytacja"):
@@ -127,4 +128,4 @@ async def ogłoszenie(ctx):
 
     await ctx.send("Wybierz typ ogłoszenia:", view=OgłoszenieView())
 
-bot.run("YOUR_TOKEN")
+bot.run(os.environ["DISCORD_TOKEN"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py


### PR DESCRIPTION
## Summary
- configure bot token and forum channel via environment variables
- document setup in README
- add Python .gitignore
- declare dependency on discord.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4a081318832f8e423b858f959c56