### PR TITLE
Add HTML export and queued auction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,21 @@ Simple Discord bot to handle auctions via forum threads.
 2. Set environment variables:
    - `DISCORD_TOKEN` - your bot token.
    - `FORUM_CHANNEL_ID` - ID of the forum channel for auctions.
+   - `HTML_EXPORT_DIR` - directory where auction HTML files will be saved (default `exports`).
+   - `AUCTION_ITEMS_FILE` - CSV file with predefined auction items (default `auction_items.csv`).
 
 3. Run the bot:
    ```bash
    python bot.py
    ```
+
+## Predefined auction items
+
+Create `auction_items.csv` with columns `title,description,start_price,increment,duration`.
+You can start the next item from the file using the command:
+
+```bash
+!start_next
+```
+
+Each auction is exported to an HTML file that can be added as a browser source in OBS.

--- a/auction_items.csv
+++ b/auction_items.csv
@@ -1,0 +1,3 @@
+title,description,start_price,increment,duration
+Pikachu,Karta elektryczna w dobrym stanie,50,2.5,1
+Charizard,Rzadki hologram,100,5,1


### PR DESCRIPTION
## Summary
- support HTML export of auctions for OBS integration
- load queued auction items from CSV file
- add `!start_next` command to start auctions from the queue

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685a51427450832f950d1d06652b94cb