### PR TITLE
Add command channel ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Simple Discord bot to handle auctions via forum threads.
 2. Set environment variables:
    - `DISCORD_TOKEN` - your bot token.
    - `FORUM_CHANNEL_ID` - ID of the forum channel for auctions.
+   - `COMMAND_CHANNEL_ID` - ID of the text channel used to invoke bot commands.
    - `HTML_EXPORT_DIR` - directory where auction HTML files will be saved (default `exports`).
    - `AUCTION_ITEMS_FILE` - CSV file with predefined auction items (default `auction_items.csv`).
 
@@ -28,6 +29,8 @@ You can start the next item from the file using the command:
 ```bash
 !start_next
 ```
+
+Run bot commands such as `!ogłoszenie` and `!start_next` only in the channel specified by `COMMAND_CHANNEL_ID`. The created auction threads will appear in the forum channel defined by `FORUM_CHANNEL_ID`.
 
 Each auction is exported to an HTML file that can be added as a browser source in OBS.
 

--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,9 @@ intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 forum_channel_id = int(os.environ["FORUM_CHANNEL_ID"])
+command_channel_id = os.environ.get("COMMAND_CHANNEL_ID")
+if command_channel_id:
+    command_channel_id = int(command_channel_id)
 active_auctions = {}  # message_id: {...}
 html_export_dir = os.environ.get("HTML_EXPORT_DIR", "exports")
 os.makedirs(html_export_dir, exist_ok=True)
@@ -188,6 +191,9 @@ async def end_auction_after(message_id, delay):
 # Komenda do uruchomienia kolejnej pozycji z listy
 @bot.command()
 async def start_next(ctx):
+    if command_channel_id and ctx.channel.id != command_channel_id:
+        await ctx.send(f"Ta komenda jest dostępna tylko na kanale <#{command_channel_id}>.")
+        return
     if not auction_queue:
         await ctx.send("Brak kolejnych kart w pliku.")
         return
@@ -205,6 +211,9 @@ async def start_next(ctx):
 # Komenda do uruchomienia ogłoszenia
 @bot.command()
 async def ogłoszenie(ctx):
+    if command_channel_id and ctx.channel.id != command_channel_id:
+        await ctx.send(f"Ta komenda jest dostępna tylko na kanale <#{command_channel_id}>.")
+        return
     options = [
         discord.SelectOption(label="Licytacja", value="licytacja", emoji="📈"),
         discord.SelectOption(label="Sprzedaż", value="sprzedaz", emoji="💰"),


### PR DESCRIPTION
## Summary
- allow specifying a command channel via `COMMAND_CHANNEL_ID`
- restrict `!start_next` and `!ogłoszenie` commands to this channel
- document new environment variable and usage instructions

## Testing
- `python -m py_compile bot.py`
- `flake8 || true`
- `DISCORD_TOKEN=dummy FORUM_CHANNEL_ID=123 COMMAND_CHANNEL_ID=456 python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685a6367c66c832f843d12f45fb77c00