### PR TITLE
Fix select callback and switch command prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Create `auction_items.csv` with columns `title,description,start_price,increment
 You can start the next item from the file using the command:
 
 ```bash
-!start_next
+/start_next
 ```
 
-Run bot commands such as `!ogłoszenie` and `!start_next` only in the channel specified by `COMMAND_CHANNEL_ID`. The created auction threads will appear in the forum channel defined by `FORUM_CHANNEL_ID`.
+Run bot commands such as `/ogłoszenie` and `/start_next` only in the channel specified by `COMMAND_CHANNEL_ID`. The created auction threads will appear in the forum channel defined by `FORUM_CHANNEL_ID`.
 
 Each auction is exported to an HTML file that can be added as a browser source in OBS.
 

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import os
 import csv
 import discord
 from discord.ext import commands
-from discord.ui import Modal, TextInput, View, Button
+from discord.ui import Modal, TextInput, View, Button, Select
 from datetime import datetime, timedelta
 import asyncio
 from dotenv import load_dotenv
@@ -11,7 +11,7 @@ load_dotenv()
 
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="!", intents=intents)
+bot = commands.Bot(command_prefix="/", intents=intents)
 
 forum_channel_id = int(os.environ["FORUM_CHANNEL_ID"])
 command_channel_id = os.environ.get("COMMAND_CHANNEL_ID")
@@ -226,7 +226,7 @@ async def ogłoszenie(ctx):
 
     class OgłoszenieView(View):
         @discord.ui.select(placeholder="Wybierz typ ogłoszenia", options=options)
-        async def select_callback(self, select, interaction: discord.Interaction):
+        async def select_callback(self, interaction: discord.Interaction, select: discord.ui.Select):
             if select.values[0] == "licytacja":
                 await interaction.response.send_modal(AuctionModal(author=interaction.user))
             else:


### PR DESCRIPTION
## Summary
- switch command prefix from `!` to `/`
- fix auction announcement select callback signature
- update README to reference new command prefix

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6b3c66c8832f8f7790cf072ae84f