### PR TITLE
Fix forum thread creation when tags required

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -95,7 +95,15 @@ async def create_auction(author, title, desc, price, increment, minutes):
     if not forum_channel:
         raise RuntimeError("Nie znaleziono kanału Forum")
 
-    post = await forum_channel.create_thread(name=title, content="Nowa licytacja!", embed=embed)
+    thread_kwargs = {
+        "name": title,
+        "content": "Nowa licytacja!",
+        "embed": embed,
+    }
+    if forum_channel.available_tags:
+        thread_kwargs["applied_tags"] = [forum_channel.available_tags[0]]
+
+    post = await forum_channel.create_thread(**thread_kwargs)
     message = await post.send(embed=embed, view=BidButton())
 
     auction = {


### PR DESCRIPTION
## Summary
- handle channels that require forum post tags when creating an auction thread

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a7205e294832f8f925a7284a66a27