### PR TITLE
Allow repeated self-bids and track reaction count

### DIFF
--- a/streaming.py
+++ b/streaming.py
@@ -32,6 +32,7 @@ body {{ font-family: Arial, sans-serif; }}
 {img_html}
 <div class='price' id='price'>{auction['price']:.2f} zł</div>
 <p>Najwyższa oferta: {leader}</p>
+<p>Liczba przebić: {auction['bid_count']}</p>
 <p>Koniec licytacji za: <span id='timer'></span></p>
 <script>
 const end = new Date('{end_iso}');


### PR DESCRIPTION
## Summary
- show running bid count in the embed and exported HTML
- increment bid count every time the 🔼 reaction is used

## Testing
- `python -m py_compile bot.py streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_685a8a16b494832fa161c648ace5d9cc